### PR TITLE
Respect configured CNAMEStrategy when checking for DNS propagation

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -115,8 +115,13 @@ func (s *Solver) Check(ctx context.Context, issuer v1.GenericIssuer, ch *cmacme.
 
 	log.V(logf.DebugLevel).Info("checking DNS propagation", "nameservers", s.Context.DNS01Nameservers)
 
+	providerConfig, err := extractChallengeSolverConfig(ch)
+	if err != nil {
+		return err
+	}
+
 	ok, err := util.PreCheckDNS(fqdn, ch.Spec.Key, s.Context.DNS01Nameservers,
-		s.Context.DNS01CheckAuthoritative)
+		s.Context.DNS01CheckAuthoritative, followCNAME(providerConfig.CNAMEStrategy))
 	if err != nil {
 		return err
 	}

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -21,7 +21,7 @@ import (
 )
 
 type preCheckDNSFunc func(fqdn, value string, nameservers []string,
-	useAuthoritative bool) (bool, error)
+	useAuthoritative bool, followCname bool) (bool, error)
 type dnsQueryFunc func(fqdn string, rtype uint16, nameservers []string, recursive bool) (in *dns.Msg, err error)
 
 var (
@@ -102,12 +102,15 @@ func followCNAMEs(fqdn string, nameservers []string, fqdnChain ...string) (strin
 
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
 func checkDNSPropagation(fqdn, value string, nameservers []string,
-	useAuthoritative bool) (bool, error) {
+	useAuthoritative bool, followCNAME bool) (bool, error) {
 
 	var err error
-	fqdn, err = followCNAMEs(fqdn, nameservers)
-	if err != nil {
-		return false, err
+	// Check if the domain has CNAME then return that
+	if followCNAME {
+		fqdn, err = followCNAMEs(fqdn, nameservers)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	if !useAuthoritative {


### PR DESCRIPTION
Respect the provider's follow CNAME strategy config when checking if the ACME challenge has been propagated. 